### PR TITLE
response validation moved to client

### DIFF
--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -68,8 +68,4 @@ class DuploService(DuploTenantResource):
     """
     tenant_id = self.tenant["TenantId"]
     res = self.duplo.post(f"subscriptions/{tenant_id}/ReplicationControllerReboot/{name}")
-    if res.status_code == 200:
-      return f"Successfully restarted service '{name}'"
-    else:
-      raise DuploError(f"Failed to restart service '{name}'")
-  
+    return {"message": f"Successfully restarted service '{name}'"}

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -67,5 +67,5 @@ class DuploService(DuploTenantResource):
       DuploError: If the service could not be restarted.
     """
     tenant_id = self.tenant["TenantId"]
-    res = self.duplo.post(f"subscriptions/{tenant_id}/ReplicationControllerReboot/{name}")
+    self.duplo.post(f"subscriptions/{tenant_id}/ReplicationControllerReboot/{name}")
     return {"message": f"Successfully restarted service '{name}'"}


### PR DESCRIPTION
before pr:
`Traceback (most recent call last):
  File "/Users/duplo-matt/.pyenv/versions/3.11.5/bin/duploctl", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/duplo-matt/.pyenv/versions/3.11.5/lib/python3.11/site-packages/duplocloud/cli.py", line 7, in main
    out = duplo.run()
          ^^^^^^^^^^^
  File "/Users/duplo-matt/.pyenv/versions/3.11.5/lib/python3.11/site-packages/duplocloud/client.py", line 151, in run
    res = svc.exec(command, args)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/duplo-matt/.pyenv/versions/3.11.5/lib/python3.11/site-packages/duplocloud/resource.py", line 20, in exec
    return command(**vars(parsed_args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/duplo-matt/.pyenv/versions/3.11.5/lib/python3.11/site-packages/duplo_resource/service.py", line 71, in restart
    if res.status_code == 200:
       ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'status_code'`
after pr:
`{"message": "Successfully restarted service 'reporting'"}`